### PR TITLE
Improve PPHUnit assertions and Travis CI setting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: php
 
 php:
   - 7.3
+  - 7.4
 
 cache:
   directories:
@@ -9,7 +10,7 @@ cache:
 
 before_script:
   - travis_retry composer self-update
-  - travis_retry composer update --prefer-source --no-interaction --dev
+  - travis_retry composer update --prefer-source --no-interaction
 
 script:
   - vendor/bin/phpunit

--- a/tests/CountryTest.php
+++ b/tests/CountryTest.php
@@ -10,7 +10,7 @@ class CountryTest extends TestCase
     public function it_has_config()
     {
         $this->assertTrue(! empty(config('profile')));
-        $this->assertTrue(in_array('CountrySeeder', config('profile.seeders')));
+        $this->assertContains('CountrySeeder', config('profile.seeders'));
     }
 
     /** @test */

--- a/tests/PhoneTypeTest.php
+++ b/tests/PhoneTypeTest.php
@@ -10,7 +10,7 @@ class PhoneTypeTest extends TestCase
     public function it_has_config()
     {
         $this->assertTrue(! empty(config('profile')));
-        $this->assertTrue(in_array('PhoneTypeSeeder', config('profile.seeders')));
+        $this->assertContains('PhoneTypeSeeder', config('profile.seeders'));
     }
 
     /** @test */
@@ -38,7 +38,7 @@ class PhoneTypeTest extends TestCase
             'Fax',
         ];
         foreach ($types as $type) {
-            $this->assertTrue(in_array($type, config('profile.data.phoneType')));
+            $this->assertContains($type, config('profile.data.phoneType'));
         }
     }
 


### PR DESCRIPTION
# Changed log

 - Using the `assertContains` to assert expected is in result array.
- Add `php-7.4` version test during Travis CI build.
- Removing the `--dev` option for `composer update --prefer-source --no-interaction` command because of following deprecated message:

```
You are using the deprecated option "--dev". It has no effect and will break in Composer 3.
```